### PR TITLE
feat(web): 카카오톡 공유 및 공유 전용 페이지, Vercel SPA 폴백

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -2,3 +2,7 @@
 # https://supabase.com/dashboard 프로젝트 설정 > API에서 확인
 VITE_SUPABASE_URL=https://xxxx.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGc...
+
+# 카카오톡 공유 (선택) - 설정 시 카카오 공유 창, 미설정 시 링크 복사
+# https://developers.kakao.com 콘솔 > 앱 > 앱 키 > JavaScript 키
+VITE_KAKAO_JAVASCRIPT_KEY=b2e75a0c7e371265782592e207fedf03

--- a/web/README.md
+++ b/web/README.md
@@ -90,3 +90,23 @@ VITE_SUPABASE_ANON_KEY=eyJhbGc...
    - `VITE_SUPABASE_ANON_KEY`
 
 배포 후 빌드가 성공하면 해당 URL에서 서비스됩니다.
+
+---
+
+## 카카오톡 공유 (모집글 공유)
+
+모집글 상세에서 **카카오톡으로 공유** 버튼을 누르면 링크를 카카오톡 방에 올릴 수 있고, 수신자가 링크를 클릭하면 **지원하기**까지 바로 진행할 수 있습니다.
+
+### 공유 링크 형식
+
+- **일반**: `https://도메인/r/모집글ID` (모집 상세 페이지)
+- **지원하기 바로 열기**: `https://도메인/r/모집글ID?apply=1` (공유 시 기본 사용)
+
+### 카카오 공유 창 사용 (선택)
+
+[Kakao Developers](https://developers.kakao.com)에서 앱을 만들고 **앱 키 > JavaScript 키**를 발급한 뒤, 환경 변수에 넣으면 **카카오톡 공유** 버튼 클릭 시 카카오 공유 창이 열립니다.
+
+- **로컬**: `web/.env`에 `VITE_KAKAO_JAVASCRIPT_KEY=발급받은_JavaScript_키`
+- **Vercel**: 프로젝트 설정 > Environment Variables에 `VITE_KAKAO_JAVASCRIPT_KEY` 추가
+
+키를 넣지 않으면 **링크 복사** 또는 (지원 시) **Web Share API**로 동작합니다.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { fetchRecruitments } from "@/lib/store";
 import Index from "./pages/index";
 import Workspace from "./pages/Workspace";
+import RecruitmentSharePage from "./pages/RecruitmentSharePage";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -26,6 +27,7 @@ const App = () => {
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/workspace/:id" element={<Workspace />} />
+          <Route path="/r/:id" element={<RecruitmentSharePage />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/web/src/components/RecruitmentDetailDialog.tsx
+++ b/web/src/components/RecruitmentDetailDialog.tsx
@@ -6,8 +6,9 @@ import {
 } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Users, Calendar, Mail, User, CheckCircle2, XCircle, Phone, Building2, LayoutDashboard } from "lucide-react";
+import { Users, Calendar, Mail, User, CheckCircle2, XCircle, Phone, Building2, LayoutDashboard, Share2 } from "lucide-react";
 import { updateRecruitment } from "@/lib/store";
+import { shareRecruitment } from "@/lib/kakao-share";
 import { toast } from "sonner";
 import ApplyDialog from "./ApplyDialog";
 
@@ -48,6 +49,11 @@ export default function RecruitmentDetailDialog({ recruitment, open, onOpenChang
     await updateRecruitment(updated);
     toast.success(`${applicant.name}님의 지원이 완료되었습니다!`);
     onUpdated();
+  };
+
+  const handleShare = async () => {
+    const result = await shareRecruitment(recruitment, { openApply: true });
+    if (result === "copy") toast.success("링크가 복사되었습니다. 카카오톡에 붙여넣기 하세요.");
   };
 
   return (
@@ -130,6 +136,10 @@ export default function RecruitmentDetailDialog({ recruitment, open, onOpenChang
             )}
 
             <div className="flex flex-col gap-2 pt-2">
+              <Button variant="secondary" size="sm" className="w-full" onClick={handleShare}>
+                <Share2 className="h-4 w-4 mr-2" />
+                카카오톡으로 공유
+              </Button>
               <div className="flex gap-2">
                 {!isClosed && (
                   <Button className="flex-1" onClick={() => setApplyOpen(true)} disabled={!!recruitment.maxMembers && recruitment.currentMembers >= recruitment.maxMembers}>

--- a/web/src/lib/kakao-share.ts
+++ b/web/src/lib/kakao-share.ts
@@ -1,0 +1,114 @@
+/**
+ * 카카오톡 공유 및 링크 공유 유틸
+ * - Kakao JS SDK 사용 시: 카카오톡 공유 창 표시
+ * - 미설정 시: Web Share API 또는 클립보드 복사
+ */
+import type { Recruitment } from "./types";
+
+const KAKAO_SDK_URL = "https://t1.kakaocdn.net/kakao_js_sdk/2.7.0/kakao.min.js";
+const SCRIPT_ID = "kakao-sdk";
+
+/** 공유용 URL 생성 (지원하기 바로 열기 옵션) */
+export function getShareUrl(recruitmentId: string, openApply = true): string {
+  const base = typeof window !== "undefined" ? window.location.origin : "";
+  const path = `/r/${recruitmentId}`;
+  return openApply ? `${base}${path}?apply=1` : `${base}${path}`;
+}
+
+/** Kakao SDK 로드 후 init (키가 있을 때만) */
+function loadKakaoAndInit(): Promise<boolean> {
+  const key = import.meta.env.VITE_KAKAO_JAVASCRIPT_KEY as string | undefined;
+  if (!key?.trim()) return Promise.resolve(false);
+
+  const w = window as Window & { Kakao?: { init: (k: string) => void; isInitialized: () => boolean } };
+  if (w.Kakao?.isInitialized?.()) return Promise.resolve(true);
+
+  return new Promise((resolve) => {
+    if (document.getElementById(SCRIPT_ID)) {
+      w.Kakao?.init?.(key);
+      resolve(true);
+      return;
+    }
+    const script = document.createElement("script");
+    script.id = SCRIPT_ID;
+    script.src = KAKAO_SDK_URL;
+    script.crossOrigin = "anonymous";
+    script.onload = () => {
+      w.Kakao?.init?.(key);
+      resolve(true);
+    };
+    script.onerror = () => resolve(false);
+    document.head.appendChild(script);
+  });
+}
+
+export type ShareResult = "kakao" | "navigator" | "copy" | "none";
+
+/**
+ * 모집글 공유 실행
+ * - Kakao 키 있음: 카카오 공유 창
+ * - 없음: Web Share API 시도 후 실패 시 클립보드 복사
+ * @returns 사용된 공유 방식 (토스트 메시지 등에 활용)
+ */
+export async function shareRecruitment(
+  recruitment: { id: string; title: string; description: string },
+  options: { openApply?: boolean } = {}
+): Promise<ShareResult> {
+  const { openApply = true } = options;
+  const url = getShareUrl(recruitment.id, openApply);
+  const title = recruitment.title;
+  const text = recruitment.description?.slice(0, 100) ?? title;
+
+  const inited = await loadKakaoAndInit();
+  const w = window as Window & {
+    Kakao?: {
+      Share: {
+        sendDefault: (arg: {
+          objectType: string;
+          content: { title: string; description?: string; imageUrl?: string; link: { webUrl: string; mobileWebUrl: string } };
+        }) => Promise<void>;
+      };
+    };
+  };
+
+  if (inited && w.Kakao?.Share?.sendDefault) {
+    try {
+      await w.Kakao.Share.sendDefault({
+        objectType: "feed",
+        content: {
+          title,
+          description: text,
+          link: { webUrl: url, mobileWebUrl: url },
+        },
+      });
+      return "kakao";
+    } catch (e) {
+      console.warn("Kakao share failed", e);
+    }
+  }
+
+  return fallbackShare(title, text, url);
+}
+
+async function fallbackShare(title: string, text: string, url: string): Promise<ShareResult> {
+  if (typeof navigator !== "undefined" && navigator.share) {
+    try {
+      await navigator.share({ title, text, url });
+      return "navigator";
+    } catch (e) {
+      if ((e as Error).name === "AbortError") return "none";
+    }
+  }
+  try {
+    await navigator.clipboard.writeText(url);
+    return "copy";
+  } catch {
+    return "none";
+  }
+}
+
+/** fallbackShare 후 클립보드 복사 성공 여부를 알 수 있게 호출부에서 사용 */
+export function copyShareUrlToClipboard(recruitmentId: string, openApply = true): Promise<boolean> {
+  const url = getShareUrl(recruitmentId, openApply);
+  return navigator.clipboard.writeText(url).then(() => true).catch(() => false);
+}

--- a/web/src/pages/RecruitmentSharePage.tsx
+++ b/web/src/pages/RecruitmentSharePage.tsx
@@ -1,0 +1,186 @@
+/**
+ * 공유 전용 모집 상세 페이지 (/r/:id?apply=1)
+ * - 카카오톡 등으로 링크 공유 시 이 URL로 진입
+ * - ?apply=1 이면 지원하기 다이얼로그 자동 오픈
+ */
+import { useState, useEffect, useCallback } from "react";
+import { useParams, useSearchParams, useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Users, Calendar, Mail, User, ArrowLeft, Share2 } from "lucide-react";
+import { fetchRecruitments, updateRecruitment } from "@/lib/store";
+import { shareRecruitment } from "@/lib/kakao-share";
+import type { Recruitment, Applicant } from "@/lib/types";
+import { toast } from "sonner";
+import ApplyDialog from "@/components/ApplyDialog";
+
+export default function RecruitmentSharePage() {
+  const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const applyParam = searchParams.get("apply") === "1";
+
+  const [recruitment, setRecruitment] = useState<Recruitment | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [applyOpen, setApplyOpen] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    setLoading(true);
+    try {
+      const list = await fetchRecruitments();
+      const found = list.find((r) => r.id === id) ?? null;
+      setRecruitment(found);
+      if (found && applyParam) setApplyOpen(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [id, applyParam]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleApply = async (applicant: Applicant) => {
+    if (!recruitment) return;
+    const applicants = recruitment.applicants ?? [];
+    const updated: Recruitment = {
+      ...recruitment,
+      currentMembers: recruitment.currentMembers + 1,
+      applicants: [...applicants, applicant],
+      status:
+        recruitment.maxMembers != null && recruitment.currentMembers + 1 >= recruitment.maxMembers
+          ? "모집완료"
+          : recruitment.status,
+    };
+    await updateRecruitment(updated);
+    toast.success(`${applicant.name}님의 지원이 완료되었습니다!`);
+    setApplyOpen(false);
+    load();
+  };
+
+  const handleShare = async () => {
+    if (!recruitment) return;
+    const result = await shareRecruitment(recruitment, { openApply: true });
+    if (result === "copy") toast.success("링크가 복사되었습니다. 카카오톡에 붙여넣기 하세요.");
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-muted-foreground">불러오는 중...</p>
+      </div>
+    );
+  }
+
+  if (!recruitment) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center gap-4 px-4">
+        <p className="text-muted-foreground">모집글을 찾을 수 없습니다.</p>
+        <Button variant="outline" onClick={() => navigate("/")}>
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          목록으로
+        </Button>
+      </div>
+    );
+  }
+
+  const isClosed = recruitment.status === "모집완료";
+  const progress =
+    recruitment.maxMembers != null
+      ? (recruitment.currentMembers / recruitment.maxMembers) * 100
+      : null;
+  const canApply =
+    !isClosed &&
+    (recruitment.maxMembers == null || recruitment.currentMembers < recruitment.maxMembers);
+
+  return (
+    <div className="min-h-screen">
+      <header className="sticky top-0 z-40 border-b border-white/10 bg-white/5 backdrop-blur-xl">
+        <div className="container mx-auto flex items-center justify-between h-14 px-4">
+          <Button variant="ghost" size="sm" onClick={() => navigate("/")}>
+            <ArrowLeft className="h-4 w-4 mr-1.5" />
+            목록
+          </Button>
+          <Button variant="outline" size="sm" onClick={handleShare}>
+            <Share2 className="h-4 w-4 mr-1.5" />
+            카카오톡으로 공유
+          </Button>
+        </div>
+      </header>
+
+      <main className="container mx-auto px-4 py-8 max-w-xl">
+        <div className="space-y-5">
+          <div className="flex items-center gap-2 flex-wrap">
+            <Badge variant={isClosed ? "closed" : "success"}>{recruitment.status}</Badge>
+            <Badge variant="secondary">{recruitment.category}</Badge>
+          </div>
+          <h1 className="text-2xl font-bold">{recruitment.title}</h1>
+          <p className="text-sm text-muted-foreground flex items-center gap-3">
+            <span className="flex items-center gap-1">
+              <User className="h-3.5 w-3.5" />
+              {recruitment.author}
+            </span>
+            <span className="flex items-center gap-1">
+              <Calendar className="h-3.5 w-3.5" />
+              {recruitment.createdAt}
+            </span>
+          </p>
+          <p className="text-sm leading-relaxed whitespace-pre-wrap">{recruitment.description}</p>
+
+          <div className="bg-secondary/50 rounded-lg p-4 space-y-3">
+            <div className="flex items-center justify-between text-sm">
+              <span className="flex items-center gap-2 text-muted-foreground">
+                <Users className="h-4 w-4" /> 인원
+              </span>
+              <span className="font-semibold">
+                {recruitment.maxMembers != null
+                  ? `${recruitment.currentMembers} / ${recruitment.maxMembers}명`
+                  : `${recruitment.currentMembers}명 (무제한)`}
+              </span>
+            </div>
+            {progress != null && (
+              <div className="w-full bg-muted rounded-full h-2 overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-primary transition-all duration-500"
+                  style={{ width: `${Math.min(progress, 100)}%` }}
+                />
+              </div>
+            )}
+            <div className="flex items-center justify-between text-sm">
+              <span className="flex items-center gap-2 text-muted-foreground">
+                <Calendar className="h-4 w-4" /> 마감일
+              </span>
+              <span className="font-semibold">{recruitment.deadline}</span>
+            </div>
+            <div className="flex items-center justify-between text-sm">
+              <span className="flex items-center gap-2 text-muted-foreground">
+                <Mail className="h-4 w-4" /> 연락처
+              </span>
+              <span className="font-semibold break-all">{recruitment.contact}</span>
+            </div>
+          </div>
+
+          {recruitment.tags.length > 0 && (
+            <div className="flex gap-2 flex-wrap">
+              {recruitment.tags.map((tag) => (
+                <Badge key={tag} variant="outline" className="text-xs">
+                  #{tag}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          {canApply && (
+            <Button className="w-full" size="lg" onClick={() => setApplyOpen(true)}>
+              <Users className="h-4 w-4 mr-2" />
+              지원하기
+            </Button>
+          )}
+        </div>
+      </main>
+
+      <ApplyDialog open={applyOpen} onOpenChange={setApplyOpen} onApply={handleApply} />
+    </div>
+  );
+}

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
- 공유 전용 라우트 /r/:id, ?apply=1 시 지원하기 자동 오픈
- RecruitmentSharePage 추가, 모집 상세·지원하기 노출
- 카카오 공유: kakao-share.ts (Kakao SDK / 링크 복사 / Web Share 폴백)
- 모집 상세 다이얼로그에 '카카오톡으로 공유' 버튼
- vercel.json: SPA rewrites로 404 방지
- .env.example: VITE_KAKAO_JAVASCRIPT_KEY 안내, README 카카오 공유 섹션

Made-with: Cursor