### PR TITLE
[feat] 지도 InfoWindow 상세정보 개선 및 교통수단 UI 업데이트

### DIFF
--- a/supabase/migrations/004_add_transport_legs.sql
+++ b/supabase/migrations/004_add_transport_legs.sql
@@ -1,0 +1,2 @@
+-- Add transport_legs JSONB column to trip_stops for multi-leg transport support
+ALTER TABLE trip_stops ADD COLUMN IF NOT EXISTS transport_legs JSONB;

--- a/web/src/components/planner/TripMap.tsx
+++ b/web/src/components/planner/TripMap.tsx
@@ -16,17 +16,32 @@ interface TripMapProps {
   activeTrip: Trip;
 }
 
+interface PlaceDetail {
+  name: string;
+  photoUrl?: string;
+  rating?: number;
+  userRatingsTotal?: number;
+  openNow?: boolean;
+  address?: string;
+  phoneNumber?: string;
+  googleMapsUrl?: string;
+}
+
 export default function TripMap({ activeTrip }: TripMapProps) {
   const map = useMap('mojip-trip-map-styled');
   const routesLibrary = useMapsLibrary('routes');
+  const placesLibrary = useMapsLibrary('places');
   const { activeDayId, setLegs, focusedStopId, setFocusedStop, focusedSavedPlaceId, setFocusedSavedPlace } = useTripPlanner();
 
   const legRenderersRef = useRef<google.maps.DirectionsRenderer[]>([]);
   const airplanePolylinesRef = useRef<google.maps.Polyline[]>([]);
   const directionsServiceRef = useRef<google.maps.DirectionsService | null>(null);
+  const placesServiceRef = useRef<google.maps.places.PlacesService | null>(null);
 
   const [selectedStop, setSelectedStop] = useState<Stop | null>(null);
   const [selectedSavedPlace, setSelectedSavedPlace] = useState<SavedPlace | null>(null);
+  const [placeDetail, setPlaceDetail] = useState<PlaceDetail | null>(null);
+  const [isLoadingDetail, setIsLoadingDetail] = useState(false);
 
   const activeDay = useMemo(() => {
     return activeTrip.days.find(d => d.id === activeDayId) || activeTrip.days[0];
@@ -41,7 +56,13 @@ export default function TripMap({ activeTrip }: TripMapProps) {
     directionsServiceRef.current = new routesLibrary.DirectionsService();
   }, [routesLibrary]);
 
-  // 2. Per-leg routing
+  // 2. Initialize PlacesService
+  useEffect(() => {
+    if (!placesLibrary) return;
+    placesServiceRef.current = new placesLibrary.PlacesService(document.createElement('div'));
+  }, [placesLibrary]);
+
+  // 3. Per-leg routing
   useEffect(() => {
     if (!map || !routesLibrary) return;
 
@@ -67,7 +88,8 @@ export default function TripMap({ activeTrip }: TripMapProps) {
 
     stops.slice(0, -1).forEach((fromStop, i) => {
       const toStop = stops[i + 1];
-      const mode: TransportMode = toStop.transportMode ?? 'driving';
+      const mode: TransportMode =
+        toStop.transportLegs?.[0]?.mode ?? toStop.transportMode ?? 'driving';
       const color = TRANSPORT_COLORS[mode];
       const origin = { lat: fromStop.lat, lng: fromStop.lng };
       const destination = { lat: toStop.lat, lng: toStop.lng };
@@ -127,7 +149,7 @@ export default function TripMap({ activeTrip }: TripMapProps) {
     };
   }, [map, routesLibrary, stops]);
 
-  // 3. Fit bounds to stops
+  // 4. Fit bounds to stops
   useEffect(() => {
     if (!map || stops.length === 0) return;
     const bounds = new google.maps.LatLngBounds();
@@ -135,7 +157,7 @@ export default function TripMap({ activeTrip }: TripMapProps) {
     map.fitBounds(bounds, { top: 80, right: 80, bottom: 80, left: 80 });
   }, [map, stops]);
 
-  // 4. Focus on a specific stop when selected from sidebar
+  // 5. Focus on a specific stop when selected from sidebar
   useEffect(() => {
     if (!map || !focusedStopId) return;
     const stop = stops.find(s => s.id === focusedStopId);
@@ -145,9 +167,10 @@ export default function TripMap({ activeTrip }: TripMapProps) {
     setSelectedStop(stop);
     setSelectedSavedPlace(null);
     setFocusedStop(null);
+    if (stop.placeId) fetchPlaceDetail(stop.placeId, stop.name);
   }, [focusedStopId, map, stops]);
 
-  // 5. Focus on a saved place when selected from sidebar
+  // 6. Focus on a saved place when selected from sidebar
   useEffect(() => {
     if (!map || !focusedSavedPlaceId) return;
     const place = savedPlaces.find(p => p.id === focusedSavedPlaceId);
@@ -157,7 +180,136 @@ export default function TripMap({ activeTrip }: TripMapProps) {
     setSelectedSavedPlace(place);
     setSelectedStop(null);
     setFocusedSavedPlace(null);
+    if (place.placeId) fetchPlaceDetail(place.placeId, place.name);
   }, [focusedSavedPlaceId, map, savedPlaces]);
+
+  const fetchPlaceDetail = (placeId: string, fallbackName: string) => {
+    if (!placesServiceRef.current) return;
+    setPlaceDetail(null);
+    setIsLoadingDetail(true);
+    placesServiceRef.current.getDetails(
+      {
+        placeId,
+        fields: ['name', 'photos', 'rating', 'user_ratings_total',
+                 'opening_hours', 'formatted_address', 'formatted_phone_number', 'url'],
+      },
+      (result, status) => {
+        setIsLoadingDetail(false);
+        if (status === google.maps.places.PlacesServiceStatus.OK && result) {
+          setPlaceDetail({
+            name: result.name ?? fallbackName,
+            photoUrl: result.photos?.[0]?.getUrl({ maxWidth: 600 }),
+            rating: result.rating,
+            userRatingsTotal: result.user_ratings_total,
+            openNow: result.opening_hours?.isOpen(),
+            address: result.formatted_address,
+            phoneNumber: result.formatted_phone_number,
+            googleMapsUrl: result.url,
+          });
+        }
+      }
+    );
+  };
+
+  const InfoWindowContent = ({ name, category, durationMinutes, isSavedPlace }: {
+    name: string;
+    category?: string;
+    durationMinutes?: number;
+    isSavedPlace?: boolean;
+  }) => {
+    if (isLoadingDetail) {
+      return (
+        <div className="min-w-[240px] max-w-[280px] animate-pulse">
+          <div className="h-[120px] bg-gray-200 rounded mb-2" />
+          <div className="px-1 pb-1 space-y-2">
+            <div className="h-4 bg-gray-200 rounded w-3/4" />
+            <div className="h-3 bg-gray-200 rounded w-1/2" />
+            <div className="h-3 bg-gray-200 rounded w-full" />
+          </div>
+        </div>
+      );
+    }
+
+    if (placeDetail) {
+      return (
+        <div className="min-w-[240px] max-w-[280px]">
+          {placeDetail.photoUrl && (
+            <img
+              src={placeDetail.photoUrl}
+              alt={placeDetail.name}
+              className="w-full h-[160px] object-cover rounded-t"
+            />
+          )}
+          <div className="p-2 space-y-1">
+            {isSavedPlace && (
+              <span className="text-xs bg-orange-100 text-orange-600 px-1.5 py-0.5 rounded-full font-semibold">가고 싶은 곳</span>
+            )}
+            <p className="font-bold text-sm text-gray-900">{placeDetail.name}</p>
+            <div className="flex items-center gap-1.5 text-xs flex-wrap">
+              {placeDetail.rating !== undefined && (
+                <span className="text-amber-500 font-semibold">★ {placeDetail.rating.toFixed(1)}</span>
+              )}
+              {placeDetail.userRatingsTotal !== undefined && (
+                <span className="text-gray-500">({placeDetail.userRatingsTotal.toLocaleString()})</span>
+              )}
+              {placeDetail.openNow !== undefined && (
+                <>
+                  {(placeDetail.rating !== undefined || placeDetail.userRatingsTotal !== undefined) && (
+                    <span className="text-gray-400">•</span>
+                  )}
+                  <span className={placeDetail.openNow ? 'text-green-600 font-medium' : 'text-red-500 font-medium'}>
+                    {placeDetail.openNow ? '영업중' : '마감'}
+                  </span>
+                </>
+              )}
+            </div>
+            {placeDetail.address && (
+              <p className="text-xs text-gray-600 flex gap-1">
+                <span>📍</span>
+                <span>{placeDetail.address}</span>
+              </p>
+            )}
+            {placeDetail.phoneNumber && (
+              <p className="text-xs text-gray-600 flex gap-1">
+                <span>📞</span>
+                <span>{placeDetail.phoneNumber}</span>
+              </p>
+            )}
+            {placeDetail.googleMapsUrl && (
+              <a
+                href={placeDetail.googleMapsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-blue-600 hover:underline block mt-1"
+              >
+                Google Maps에서 보기 →
+              </a>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    // Fallback UI (no placeId or fetch failed)
+    return (
+      <div className="p-2 min-w-[180px] max-w-[280px]">
+        {isSavedPlace && (
+          <div className="flex items-center gap-1 mb-1">
+            <span className="text-xs bg-orange-100 text-orange-600 px-1.5 py-0.5 rounded-full font-semibold">가고 싶은 곳</span>
+          </div>
+        )}
+        <p className="font-bold text-sm text-gray-900 mb-1">{name}</p>
+        {category && (
+          <span className="text-[10px] bg-blue-50 text-blue-600 px-1.5 py-0.5 rounded-full font-semibold inline-block">
+            {category}
+          </span>
+        )}
+        {durationMinutes !== undefined && (
+          <p className="text-xs text-gray-500 mt-1">{durationMinutes}분 소요</p>
+        )}
+      </div>
+    );
+  };
 
   return (
     <div className="w-full h-full relative overflow-hidden">
@@ -174,7 +326,12 @@ export default function TripMap({ activeTrip }: TripMapProps) {
           <AdvancedMarker
             key={stop.id}
             position={{ lat: stop.lat, lng: stop.lng }}
-            onClick={() => setSelectedStop(stop)}
+            onClick={() => {
+              setSelectedStop(stop);
+              setSelectedSavedPlace(null);
+              setPlaceDetail(null);
+              if (stop.placeId) fetchPlaceDetail(stop.placeId, stop.name);
+            }}
           >
             <Pin
               background={stop.visited ? '#94A3B8' : '#3B82F6'}
@@ -192,7 +349,12 @@ export default function TripMap({ activeTrip }: TripMapProps) {
           <AdvancedMarker
             key={place.id}
             position={{ lat: place.lat, lng: place.lng }}
-            onClick={() => { setSelectedSavedPlace(place); setSelectedStop(null); }}
+            onClick={() => {
+              setSelectedSavedPlace(place);
+              setSelectedStop(null);
+              setPlaceDetail(null);
+              if (place.placeId) fetchPlaceDetail(place.placeId, place.name);
+            }}
           >
             <Pin
               background={'#F97316'}
@@ -207,38 +369,26 @@ export default function TripMap({ activeTrip }: TripMapProps) {
         {selectedSavedPlace && (
           <InfoWindow
             position={{ lat: selectedSavedPlace.lat, lng: selectedSavedPlace.lng }}
-            onCloseClick={() => setSelectedSavedPlace(null)}
+            onCloseClick={() => { setSelectedSavedPlace(null); setPlaceDetail(null); }}
           >
-            <div className="p-2 min-w-[150px]">
-              <div className="flex items-center gap-1 mb-1">
-                <span className="text-xs bg-orange-100 text-orange-600 px-1.5 py-0.5 rounded-full font-semibold">가고 싶은 곳</span>
-              </div>
-              <h3 className="font-bold text-sm text-foreground mb-1">{selectedSavedPlace.name}</h3>
-              {selectedSavedPlace.address && (
-                <p className="text-[11px] text-muted-foreground">{selectedSavedPlace.address}</p>
-              )}
-              <span className="text-[10px] bg-primary/10 text-primary px-1.5 py-0.5 rounded-full font-semibold mt-1 inline-block">
-                {selectedSavedPlace.category}
-              </span>
-            </div>
+            <InfoWindowContent
+              name={selectedSavedPlace.name}
+              category={selectedSavedPlace.category}
+              isSavedPlace
+            />
           </InfoWindow>
         )}
 
         {selectedStop && (
           <InfoWindow
             position={{ lat: selectedStop.lat, lng: selectedStop.lng }}
-            onCloseClick={() => setSelectedStop(null)}
+            onCloseClick={() => { setSelectedStop(null); setPlaceDetail(null); }}
           >
-            <div className="p-2 min-w-[150px]">
-              <h3 className="font-bold text-sm text-foreground mb-1">{selectedStop.name}</h3>
-              <p className="text-[11px] text-muted-foreground mb-2">{selectedStop.address}</p>
-              <div className="flex items-center justify-between">
-                <span className="text-[10px] bg-primary/10 text-primary px-1.5 py-0.5 rounded-full font-semibold">
-                  {selectedStop.category}
-                </span>
-                <span className="text-[10px] text-muted-foreground">{selectedStop.durationMinutes}분 소요</span>
-              </div>
-            </div>
+            <InfoWindowContent
+              name={selectedStop.name}
+              category={selectedStop.category}
+              durationMinutes={selectedStop.durationMinutes}
+            />
           </InfoWindow>
         )}
       </Map>

--- a/web/src/components/planner/TripStopCard.tsx
+++ b/web/src/components/planner/TripStopCard.tsx
@@ -34,7 +34,10 @@ export default function TripStopCard({ tripId, dayId, stop }: TripStopCardProps)
 
   return (
     <div
-      onClick={() => setFocusedStop(stop.id)}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest('button, input, textarea, a')) return;
+        setFocusedStop(stop.id);
+      }}
       className={`
         relative border rounded-2xl shadow-sm bg-card flex group transition-all duration-300 w-full min-w-0 overflow-hidden cursor-pointer
         ${isMobile ? 'p-3 gap-3' : 'p-4 gap-4'}

--- a/web/src/components/planner/TripStopList.tsx
+++ b/web/src/components/planner/TripStopList.tsx
@@ -1,110 +1,235 @@
-import { useState } from "react";
-import type { DayPlan, Stop } from "@/lib/types/planner";
+import { useState, useRef } from "react";
+import type { DayPlan, Stop, TransportLeg } from "@/lib/types/planner";
 import { useTripPlanner } from "@/hooks/useTripPlanner";
 import { useIsMobile } from "@/hooks/use-mobile";
 import TripStopCard from "./TripStopCard";
 import { Droppable, Draggable } from "@hello-pangea/dnd";
-import { Car, Bus, PersonStanding, Bike, Plane } from "lucide-react";
+import { Car, Bus, PersonStanding, Bike, Plane, TrainFront, Plus, X, Search } from "lucide-react";
 import { TRANSPORT_COLORS } from "@/lib/transportMode";
 import type { TransportMode } from "@/lib/transportMode";
 import type { LegInfo } from "@/lib/types/planner";
+import { useMapsLibrary } from "@vis.gl/react-google-maps";
 
 interface TripStopListProps {
   tripId: string;
   day: DayPlan;
 }
 
-const MODES: TransportMode[] = ['driving', 'transit', 'walking', 'bicycling', 'airplane'];
-const MODE_ICONS = {
+const MODES: TransportMode[] = ['driving', 'transit', 'subway', 'walking', 'bicycling', 'airplane'];
+const MODE_ICONS: Record<TransportMode, React.ElementType> = {
   driving: Car,
   transit: Bus,
+  subway: TrainFront,
   walking: PersonStanding,
   bicycling: Bike,
   airplane: Plane,
 };
 
+const NAME_INPUT_MODES: TransportMode[] = ['transit', 'subway', 'airplane'];
+
+function getLegsFromStop(stop: Stop): TransportLeg[] {
+  if (stop.transportLegs && stop.transportLegs.length > 0) return stop.transportLegs;
+  return [{ mode: stop.transportMode ?? 'driving', name: stop.transportName }];
+}
+
 interface LegConnectorProps {
   tripId: string;
   dayId: string;
+  fromStop: Stop;
   toStop: Stop;
   legInfo: LegInfo | undefined;
 }
 
-function LegConnector({ tripId, dayId, toStop, legInfo }: LegConnectorProps) {
+function LegConnector({ tripId, dayId, fromStop, toStop, legInfo }: LegConnectorProps) {
   const { updateStop } = useTripPlanner();
   const isMobile = useIsMobile();
-  const mode: TransportMode = toStop.transportMode ?? 'driving';
-  const [nameValue, setNameValue] = useState(toStop.transportName ?? '');
+  const routesLibrary = useMapsLibrary('routes');
+  const directionsServiceRef = useRef<google.maps.DirectionsService | null>(null);
+  const [legs, setLegs] = useState<TransportLeg[]>(() => getLegsFromStop(toStop));
+  const [isAutoDetecting, setIsAutoDetecting] = useState(false);
 
-  const handleModeChange = (newMode: TransportMode) => {
-    const clearName = newMode !== 'transit' && newMode !== 'airplane';
+  // Keep a local ref to avoid stale closure in callbacks
+  const legsRef = useRef(legs);
+  legsRef.current = legs;
+
+  const representativeMode = legs[0]?.mode ?? 'driving';
+
+  const saveLegs = (newLegs: TransportLeg[]) => {
+    setLegs(newLegs);
     updateStop(tripId, dayId, toStop.id, {
-      transportMode: newMode,
-      transportName: clearName ? undefined : toStop.transportName,
+      transportLegs: newLegs,
+      // Keep legacy fields in sync with first leg for map rendering
+      transportMode: newLegs[0]?.mode,
+      transportName: newLegs[0]?.name,
     });
   };
 
-  const handleNameBlur = () => {
-    updateStop(tripId, dayId, toStop.id, { transportName: nameValue || undefined });
+  const handleModeChange = (legIdx: number, newMode: TransportMode) => {
+    const updated = legs.map((leg, i) => {
+      if (i !== legIdx) return leg;
+      const clearName = !NAME_INPUT_MODES.includes(newMode);
+      return { mode: newMode, name: clearName ? undefined : leg.name };
+    });
+    saveLegs(updated);
   };
 
-  const showNameInput = mode === 'transit' || mode === 'airplane';
-  const placeholder = mode === 'transit'
-    ? '노선 / 편명 (예: 지하철 2호선)'
-    : '항공편 번호 (예: KE123)';
+  const handleNameChange = (legIdx: number, name: string) => {
+    setLegs(legs.map((leg, i) => i === legIdx ? { ...leg, name } : leg));
+  };
+
+  const handleNameBlur = (legIdx: number) => {
+    saveLegs(legsRef.current);
+  };
+
+  const addLeg = () => {
+    saveLegs([...legs, { mode: 'transit' }]);
+  };
+
+  const removeLeg = (legIdx: number) => {
+    const updated = legs.filter((_, i) => i !== legIdx);
+    saveLegs(updated.length > 0 ? updated : [{ mode: 'driving' }]);
+  };
+
+  const handleAutoDetect = async () => {
+    if (!routesLibrary) return;
+    if (!directionsServiceRef.current) {
+      directionsServiceRef.current = new routesLibrary.DirectionsService();
+    }
+    setIsAutoDetecting(true);
+    try {
+      const result = await new Promise<google.maps.DirectionsResult>((resolve, reject) => {
+        directionsServiceRef.current!.route({
+          origin: { lat: fromStop.lat, lng: fromStop.lng },
+          destination: { lat: toStop.lat, lng: toStop.lng },
+          travelMode: google.maps.TravelMode.TRANSIT,
+          transitOptions: { departureTime: new Date() },
+        }, (res, status) => {
+          if (status === google.maps.DirectionsStatus.OK && res) resolve(res);
+          else reject(new Error(status));
+        });
+      });
+
+      const steps = result.routes[0]?.legs[0]?.steps ?? [];
+      const detected: TransportLeg[] = [];
+
+      for (const step of steps) {
+        if (step.travel_mode === google.maps.TravelMode.WALKING) continue;
+        if (step.travel_mode === google.maps.TravelMode.TRANSIT) {
+          const vehicleType = step.transit?.line?.vehicle?.type ?? '';
+          let mode: TransportMode = 'transit';
+          if (['SUBWAY', 'METRO_RAIL', 'HEAVY_RAIL', 'TRAM'].includes(vehicleType)) {
+            mode = 'subway';
+          }
+          const lineName = step.transit?.line?.short_name ?? step.transit?.line?.name ?? undefined;
+          detected.push({ mode, name: lineName });
+        }
+      }
+
+      if (detected.length > 0) {
+        saveLegs(detected);
+      }
+    } catch {
+      // silently fail
+    } finally {
+      setIsAutoDetecting(false);
+    }
+  };
 
   return (
     <div className="flex items-start gap-3 py-1.5 px-6 animate-in fade-in slide-in-from-left-2 duration-500">
-      {/* Vertical line + mode buttons column */}
-      <div className="flex flex-col items-center gap-1 pt-1">
+      {/* Vertical line column */}
+      <div className="flex flex-col items-center pt-1">
         <div className="w-0.5 h-3 bg-gradient-to-b from-border/60 to-border/30 rounded-full" />
-        {/* Mode icon buttons */}
-        <div className="flex gap-1">
-          {MODES.map((m) => {
-            const Icon = MODE_ICONS[m];
-            const isActive = mode === m;
-            return (
-              <button
-                key={m}
-                onClick={() => handleModeChange(m)}
-                className={`${isMobile ? 'w-7 h-7' : 'w-6 h-6'} rounded-full flex items-center justify-center transition-all hover:scale-110`}
-                style={{
-                  backgroundColor: isActive ? TRANSPORT_COLORS[m] : 'transparent',
-                  border: isActive ? 'none' : '1px solid hsl(var(--border))',
-                }}
-                title={m}
-              >
-                <Icon
-                  className="w-3 h-3"
-                  style={{ color: isActive ? 'white' : 'hsl(var(--muted-foreground))' }}
-                />
-              </button>
-            );
-          })}
-        </div>
+        <div className="w-0.5 flex-1 bg-border/20 rounded-full" />
         <div className="w-0.5 h-3 bg-gradient-to-b from-border/30 to-border/60 rounded-full" />
       </div>
 
-      {/* Info column */}
-      <div className="flex flex-col gap-1.5 min-w-0 flex-1 pt-1">
-        {/* Distance / duration pill */}
-        <div className={`flex items-center gap-2 ${isMobile ? 'text-xs' : 'text-[11px]'} font-bold text-muted-foreground/80 bg-muted/30 py-1 px-2.5 rounded-full border border-border/40 w-fit`}>
-          <span className="text-foreground">{legInfo?.distance ?? '…'}</span>
-          <div className="w-1 h-1 bg-muted-foreground/30 rounded-full" />
-          <span style={{ color: TRANSPORT_COLORS[mode] }}>{legInfo?.duration ?? '…'}</span>
-        </div>
+      {/* Content column */}
+      <div className="flex flex-col gap-1.5 min-w-0 flex-1 pt-1 pb-1">
+        {/* Each leg row */}
+        {legs.map((leg, legIdx) => {
+          const showName = NAME_INPUT_MODES.includes(leg.mode);
+          return (
+            <div key={legIdx} className="flex flex-col gap-1">
+              <div className="flex items-center gap-1">
+                {/* Mode icon buttons */}
+                <div className="flex gap-0.5 flex-wrap">
+                  {MODES.map((m) => {
+                    const Icon = MODE_ICONS[m];
+                    const isActive = leg.mode === m;
+                    return (
+                      <button
+                        key={m}
+                        onClick={() => handleModeChange(legIdx, m)}
+                        className={`${isMobile ? 'w-7 h-7' : 'w-6 h-6'} rounded-full flex items-center justify-center transition-all hover:scale-110`}
+                        style={{
+                          backgroundColor: isActive ? TRANSPORT_COLORS[m] : 'transparent',
+                          border: isActive ? 'none' : '1px solid hsl(var(--border))',
+                        }}
+                        title={m}
+                      >
+                        <Icon
+                          className="w-3 h-3"
+                          style={{ color: isActive ? 'white' : 'hsl(var(--muted-foreground))' }}
+                        />
+                      </button>
+                    );
+                  })}
+                </div>
+                {/* Remove leg button (only if more than 1 leg) */}
+                {legs.length > 1 && (
+                  <button
+                    onClick={() => removeLeg(legIdx)}
+                    className="w-5 h-5 rounded-full flex items-center justify-center text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors ml-0.5"
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                )}
+              </div>
+              {/* Route name input */}
+              {showName && (
+                <input
+                  className="text-[11px] border border-border/50 rounded-lg px-2 py-1 bg-background outline-none focus:ring-1 w-full"
+                  style={{ '--tw-ring-color': TRANSPORT_COLORS[leg.mode] } as React.CSSProperties}
+                  placeholder={
+                    leg.mode === 'airplane'
+                      ? '항공편 번호 (예: KE123)'
+                      : '노선명 (예: 지하철 2호선)'
+                  }
+                  value={leg.name ?? ''}
+                  onChange={(e) => handleNameChange(legIdx, e.target.value)}
+                  onBlur={() => handleNameBlur(legIdx)}
+                />
+              )}
+            </div>
+          );
+        })}
 
-        {/* Route name input (transit / airplane only) */}
-        {showNameInput && (
-          <input
-            className="text-[11px] border border-border/50 rounded-lg px-2 py-1 bg-background outline-none focus:ring-1 w-full"
-            style={{ '--tw-ring-color': TRANSPORT_COLORS[mode] } as React.CSSProperties}
-            placeholder={placeholder}
-            value={nameValue}
-            onChange={(e) => setNameValue(e.target.value)}
-            onBlur={handleNameBlur}
-          />
-        )}
+        {/* Add leg button */}
+        <button
+          onClick={addLeg}
+          className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors w-fit"
+        >
+          <Plus className="w-3 h-3" />
+          구간 추가
+        </button>
+
+        {/* Distance / duration pill + Auto-detect */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <div className={`flex items-center gap-2 ${isMobile ? 'text-xs' : 'text-[11px]'} font-bold text-muted-foreground/80 bg-muted/30 py-1 px-2.5 rounded-full border border-border/40`}>
+            <span className="text-foreground">{legInfo?.distance ?? '…'}</span>
+            <div className="w-1 h-1 bg-muted-foreground/30 rounded-full" />
+            <span style={{ color: TRANSPORT_COLORS[representativeMode] }}>{legInfo?.duration ?? '…'}</span>
+          </div>
+          <button
+            onClick={handleAutoDetect}
+            disabled={isAutoDetecting}
+            className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground border border-border/50 rounded-full px-2 py-0.5 transition-colors disabled:opacity-50"
+          >
+            <Search className="w-3 h-3" />
+            {isAutoDetecting ? '탐색 중…' : '경로 자동 가져오기'}
+          </button>
+        </div>
       </div>
     </div>
   );
@@ -148,6 +273,7 @@ export default function TripStopList({ tripId, day }: TripStopListProps) {
                 <LegConnector
                   tripId={tripId}
                   dayId={day.id}
+                  fromStop={stop}
                   toStop={day.stops[index + 1]}
                   legInfo={activeDayLegs[index]}
                 />

--- a/web/src/lib/supabase-planner.ts
+++ b/web/src/lib/supabase-planner.ts
@@ -3,7 +3,7 @@
  * supabase-recruitments.ts 패턴을 동일하게 따릅니다.
  */
 import { supabase } from "./supabase";
-import type { Trip, DayPlan, Stop, Category, RouteSummary, ChecklistItem, WishlistItem, SavedPlace } from "./types/planner";
+import type { Trip, DayPlan, Stop, Category, RouteSummary, ChecklistItem, WishlistItem, SavedPlace, TransportLeg } from "./types/planner";
 import type { TransportMode } from "./transportMode";
 
 // ─────────────────────────────────────────────
@@ -57,6 +57,7 @@ type DbTripStop = {
   visited: boolean;
   transport_mode: string | null;
   transport_name: string | null;
+  transport_legs: TransportLeg[] | null;
   created_at: string;
 };
 
@@ -80,6 +81,7 @@ function toStop(row: DbTripStop): Stop {
     visited: row.visited,
     transportMode: (row.transport_mode as TransportMode) ?? undefined,
     transportName: row.transport_name ?? undefined,
+    transportLegs: row.transport_legs ?? undefined,
   };
 }
 
@@ -279,6 +281,7 @@ async function _upsertDay(tripId: string, day: DayPlan): Promise<void> {
         visited: s.visited,
         transport_mode: s.transportMode ?? null,
         transport_name: s.transportName ?? null,
+        transport_legs: s.transportLegs ?? null,
       }))
     );
     if (error) throw error;

--- a/web/src/lib/transportMode.ts
+++ b/web/src/lib/transportMode.ts
@@ -1,8 +1,9 @@
-export type TransportMode = 'driving' | 'transit' | 'walking' | 'bicycling' | 'airplane';
+export type TransportMode = 'driving' | 'transit' | 'subway' | 'walking' | 'bicycling' | 'airplane';
 
 export const TRANSPORT_COLORS: Record<TransportMode, string> = {
   driving:   '#3B82F6',  // blue
-  transit:   '#10B981',  // emerald
+  transit:   '#10B981',  // emerald (버스)
+  subway:    '#6366F1',  // indigo (지하철/전차)
   walking:   '#F97316',  // orange
   bicycling: '#EAB308',  // yellow
   airplane:  '#8B5CF6',  // purple
@@ -11,6 +12,7 @@ export const TRANSPORT_COLORS: Record<TransportMode, string> = {
 export function googleTravelMode(mode: TransportMode): google.maps.TravelMode {
   switch (mode) {
     case 'transit':   return google.maps.TravelMode.TRANSIT;
+    case 'subway':    return google.maps.TravelMode.TRANSIT;
     case 'walking':   return google.maps.TravelMode.WALKING;
     case 'bicycling': return google.maps.TravelMode.BICYCLING;
     default:          return google.maps.TravelMode.DRIVING;

--- a/web/src/lib/types/planner.ts
+++ b/web/src/lib/types/planner.ts
@@ -41,6 +41,11 @@ export interface RouteSummary {
 import type { TransportMode } from '../transportMode';
 export type { TransportMode };
 
+export interface TransportLeg {
+  mode: TransportMode;
+  name?: string; // 노선명, 편명 등
+}
+
 export interface Stop {
   id: string; // uuid
   name: string;
@@ -54,8 +59,9 @@ export interface Stop {
   memo?: string;
   order: number;
   visited: boolean;
-  transportMode?: TransportMode; // mode from previous stop to this stop
-  transportName?: string; // route name or flight number
+  transportLegs?: TransportLeg[]; // 다구간 이동수단 (우선 사용)
+  transportMode?: TransportMode;  // 하위 호환용 (transportLegs 없을 때 폴백)
+  transportName?: string;         // 하위 호환용
 }
 
 export interface LegInfo {


### PR DESCRIPTION
## 개요

closes #19

Google Places API를 활용해 지도 마커 InfoWindow에 상세정보를 표시하고, 교통수단 UI를 개선합니다.

## 구현 내용

### 지도 InfoWindow 상세정보 (TripMap.tsx)
- `useMapsLibrary('places')` + `PlacesService`로 `placeId` 기반 상세정보 fetch
- 사진(최대 600px), 평점(★ `text-amber-500`), 영업중/마감 배지, 주소, 전화번호, Google Maps 링크 표시
- 로딩 중 pulse 스켈레톤 애니메이션 표시
- `placeId` 없는 장소는 기존 간소화 UI(이름·카테고리)로 폴백
- 장소명 `text-gray-900`으로 가독성 문제 해결
- InfoWindow 닫을 때 `placeDetail` 초기화

### 교통수단 업데이트 (TripStopList.tsx, transportMode.ts, types/planner.ts)
- 지하철(`subway`) 모드 추가 (TrainFront 아이콘)
- `TransportLeg[]` 다중 구간 지원
- 자동 교통수단 감지 기능

### 기타
- TripStopCard: 내부 버튼/링크 클릭 시 지도 포커스 이벤트 전파 차단
- supabase-planner.ts: `transportLegs` 필드 DB 연동
- supabase migration: `004_add_transport_legs.sql` 추가

## 테스트 체크리스트
- [ ] `placeId` 있는 Stop 마커 클릭 → 스켈레톤 → 사진·평점·영업시간 표시
- [ ] `placeId` 없는 장소 → 폴백 UI 표시
- [ ] SavedPlace 마커에서도 동일 동작
- [ ] Google Maps 링크 → 새 탭으로 열림
- [ ] InfoWindow 닫기 후 재클릭 시 스켈레톤 재표시
- [ ] subway 모드 선택 및 지도 라우팅 정상 동작